### PR TITLE
feat: delegate topic detection to n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ deno cache --lock=lock.json chatbot.ts
 BOT_TOKEN=YOUR_BOT_TOKEN
 OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY
 OPENROUTER_MODEL=cognitivecomputations/dolphin-mistral-24b-venice-edition:free
+N8N_TOPIC_URL=https://your-n8n-endpoint.example
+N8N_TIMEOUT_MS=5000
 ```
+
+`N8N_TOPIC_URL` and `N8N_TIMEOUT_MS` are optional and enable topic analysis
+through an n8n workflow.
 
 To get your API key, see [Get OpenRouter API Key](#-get-openrouter-api-key).
 

--- a/chatbot.ts
+++ b/chatbot.ts
@@ -12,22 +12,15 @@ async function logDialog(
   userName: string,
   userMessage: string,
   botResponse: string,
-  isAutoComment: boolean = false
+  isAutoComment: boolean = false,
 ) {
   const timestamp = new Date().toISOString();
-  const logEntry = {
-    timestamp,
-    chatId,
-    chatType,
-    userName,
-    userMessage,
-    botResponse,
-    isAutoComment,
-    separator: "---"
-  };
-  
-  const logLine = `[${timestamp}] ${chatType} | ${userName} (${chatId}): "${userMessage}" → BOT: "${botResponse}" ${isAutoComment ? "(AUTO)" : ""}\n${"=".repeat(100)}\n`;
-  
+
+  const logLine =
+    `[${timestamp}] ${chatType} | ${userName} (${chatId}): "${userMessage}" → BOT: "${botResponse}" ${
+      isAutoComment ? "(AUTO)" : ""
+    }\n${"=".repeat(100)}\n`;
+
   try {
     await Deno.writeTextFile("dialogs.log", logLine, { append: true });
   } catch (error) {
@@ -52,9 +45,18 @@ const COMMENT_ALL_MESSAGES = Deno.env.get("COMMENT_ALL_MESSAGES") === "true";
 // Настройка постоянного стиля общения
 const DEFAULT_STYLE = Deno.env.get("DEFAULT_STYLE") || "";
 // Настройки автокомментирования
-const AUTO_COMMENT_CHANCE = parseInt(Deno.env.get("AUTO_COMMENT_CHANCE") || "15"); // Шанс в %
-const MIN_MESSAGES_TO_TRIGGER = parseInt(Deno.env.get("MIN_MESSAGES_TO_TRIGGER") || "3"); // Минимум сообщений
-const AUTO_COMMENT_COOLDOWN = parseInt(Deno.env.get("AUTO_COMMENT_COOLDOWN") || "300"); // Пауза в секундах
+const AUTO_COMMENT_CHANCE = parseInt(
+  Deno.env.get("AUTO_COMMENT_CHANCE") || "15",
+); // Шанс в %
+const MIN_MESSAGES_TO_TRIGGER = parseInt(
+  Deno.env.get("MIN_MESSAGES_TO_TRIGGER") || "3",
+); // Минимум сообщений
+const AUTO_COMMENT_COOLDOWN = parseInt(
+  Deno.env.get("AUTO_COMMENT_COOLDOWN") || "300",
+); // Пауза в секундах
+// Настройки анализа темы через n8n
+const N8N_TOPIC_URL = Deno.env.get("N8N_TOPIC_URL");
+const N8N_TIMEOUT_MS = parseInt(Deno.env.get("N8N_TIMEOUT_MS") || "5000");
 
 if (!BOT_TOKEN || !OPENROUTER_API_KEY) {
   logWithTime("⛔️ BOT_TOKEN and OPENROUTER_API_KEY must be set");
@@ -100,9 +102,9 @@ const chatContext = new Map<
 // Система отслеживания активности чатов для автокомментирования
 const chatActivity = new Map<
   number,
-  { 
-    messageCount: number; 
-    lastMessages: Array<{text: string; timestamp: number; userName: string}>;
+  {
+    messageCount: number;
+    lastMessages: Array<{ text: string; timestamp: number; userName: string }>;
     lastAutoComment: number;
     lastMessageTime: number;
     isInitialized: boolean; // Флаг инициализации контекста
@@ -111,43 +113,38 @@ const chatActivity = new Map<
   }
 >();
 
-// Функция для анализа темы разговора
-function analyzeTopic(messages: Array<{text: string; userName: string}>): string {
-  if (messages.length === 0) return "общий";
-  
-  // Собираем все слова из последних сообщений
-  const allWords = messages
-    .map(msg => msg.text.toLowerCase())
-    .join(" ")
-    .split(/\s+/)
-    .filter(word => word.length > 3); // Игнорируем короткие слова
-  
-  // Простые ключевые слова для определения темы
-  const topics = {
-    "технологии": ["программирование", "код", "разработка", "технологии", "айти", "программист", "разработчик"],
-    "работа": ["работа", "проект", "задача", "дедлайн", "начальник", "коллега", "офис"],
-    "развлечения": ["фильм", "игра", "музыка", "концерт", "вечеринка", "отдых", "развлечения"],
-    "спорт": ["спорт", "футбол", "тренировка", "зал", "бег", "фитнес"],
-    "политика": ["политика", "выборы", "правительство", "закон", "новости"],
-    "семья": ["семья", "дети", "муж", "жена", "родители", "дом"]
-  };
-  
-  // Подсчитываем совпадения для каждой темы
-  const topicScores: {[key: string]: number} = {};
-  
-  for (const [topic, keywords] of Object.entries(topics)) {
-    topicScores[topic] = keywords.reduce((score, keyword) => {
-      return score + (allWords.includes(keyword) ? 1 : 0);
-    }, 0);
+// Функция для анализа темы разговора через n8n
+async function analyzeTopic(
+  messages: Array<{ text: string; userName: string }>,
+): Promise<string> {
+  if (!N8N_TOPIC_URL) return "общий";
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), N8N_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(N8N_TOPIC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const text = await resp.text();
+    try {
+      const data = JSON.parse(text);
+      if (typeof data === "string") return data || "общий";
+      if (typeof data.topic === "string") return data.topic || "общий";
+      if (typeof data.label === "string") return data.label || "общий";
+      return "общий";
+    } catch {
+      return text.trim() || "общий";
+    }
+  } catch (error) {
+    logWithTime("⚠️ Ошибка анализа темы через n8n:", error?.message || error);
+    return "общий";
   }
-  
-  // Находим тему с наибольшим количеством совпадений
-  const maxScore = Math.max(...Object.values(topicScores));
-  const detectedTopic = maxScore > 0 
-    ? Object.keys(topicScores).find(topic => topicScores[topic] === maxScore) || "общий"
-    : "общий";
-  
-  return detectedTopic;
 }
 
 // Функция для инициализации контекста чата при перезапуске
@@ -156,49 +153,56 @@ async function initializeChatContext(chatId: number): Promise<void> {
     // Получаем последние 30 сообщений из чата
     const updates = await bot.getUpdates({
       limit: 100, // Получаем больше обновлений для поиска нужного чата
-      timeout: 1
+      timeout: 1,
     });
-    
+
     // Фильтруем сообщения для конкретного чата
     const chatMessages = updates
-      .filter(update => update.message?.chat.id === chatId)
-      .map(update => update.message)
-      .filter(msg => msg && msg.text && !msg.from?.is_bot)
+      .filter((update) => update.message?.chat.id === chatId)
+      .map((update) => update.message)
+      .filter((msg) => msg && msg.text && !msg.from?.is_bot)
       .slice(-30); // Берем последние 30 сообщений
-    
-         if (chatMessages.length > 0) {
-       const activity = chatActivity.get(chatId) || {
-         messageCount: 0,
-         lastMessages: [],
-         lastAutoComment: 0,
-         lastMessageTime: 0,
-         isInitialized: false,
-         currentTopic: "общий",
-         topicChangeTime: Date.now()
-       };
-       
-       // Добавляем исторические сообщения в контекст
-       const now = Date.now();
-       activity.lastMessages = chatMessages.map(msg => ({
-         text: msg.text!,
-         timestamp: now - (chatMessages.length - chatMessages.indexOf(msg)) * 60000, // Примерное время
-         userName: msg.from?.first_name || msg.from?.username || "Unknown"
-       }));
-       
-       // Определяем начальную тему
-       activity.currentTopic = analyzeTopic(activity.lastMessages);
-       activity.isInitialized = true;
-       chatActivity.set(chatId, activity);
-       
-       logWithTime(`📚 Инициализирован контекст для чата ${chatId} с ${chatMessages.length} сообщениями, тема: ${activity.currentTopic}`);
-     }
+
+    if (chatMessages.length > 0) {
+      const activity = chatActivity.get(chatId) || {
+        messageCount: 0,
+        lastMessages: [],
+        lastAutoComment: 0,
+        lastMessageTime: 0,
+        isInitialized: false,
+        currentTopic: "общий",
+        topicChangeTime: Date.now(),
+      };
+
+      // Добавляем исторические сообщения в контекст
+      const now = Date.now();
+      activity.lastMessages = chatMessages.map((msg) => ({
+        text: msg.text!,
+        timestamp: now -
+          (chatMessages.length - chatMessages.indexOf(msg)) * 60000, // Примерное время
+        userName: msg.from?.first_name || msg.from?.username || "Unknown",
+      }));
+
+      // Определяем начальную тему через n8n
+      activity.currentTopic = await analyzeTopic(activity.lastMessages);
+      activity.isInitialized = true;
+      chatActivity.set(chatId, activity);
+
+      logWithTime(
+        `📚 Инициализирован контекст для чата ${chatId} с ${chatMessages.length} сообщениями, тема: ${activity.currentTopic}`,
+      );
+    }
   } catch (error) {
     logWithTime(`❌ Ошибка инициализации контекста для чата ${chatId}:`, error);
   }
 }
 
 // Функция для проверки, нужно ли боту автоматически комментировать
-function shouldAutoComment(chatId: number, messageText: string, userName: string): boolean {
+async function shouldAutoComment(
+  chatId: number,
+  messageText: string,
+  userName: string,
+): Promise<boolean> {
   const now = Date.now();
   const activity = chatActivity.get(chatId) || {
     messageCount: 0,
@@ -207,37 +211,42 @@ function shouldAutoComment(chatId: number, messageText: string, userName: string
     lastMessageTime: 0,
     isInitialized: false,
     currentTopic: "общий",
-    topicChangeTime: now
+    topicChangeTime: now,
   };
 
   // Обновляем активность
   activity.messageCount++;
-  activity.lastMessages.push({text: messageText, timestamp: now, userName});
+  activity.lastMessages.push({ text: messageText, timestamp: now, userName });
   activity.lastMessageTime = now;
-  
+
   // Удаляем сообщения старше 5 минут (300 секунд)
   const fiveMinutesAgo = now - (5 * 60 * 1000);
-  activity.lastMessages = activity.lastMessages.filter(msg => msg.timestamp > fiveMinutesAgo);
-  
+  activity.lastMessages = activity.lastMessages.filter((msg) =>
+    msg.timestamp > fiveMinutesAgo
+  );
+
   // Анализируем текущую тему
-  const newTopic = analyzeTopic(activity.lastMessages);
+  const newTopic = await analyzeTopic(activity.lastMessages);
   const topicChanged = newTopic !== activity.currentTopic;
-  
+
   if (topicChanged) {
     activity.currentTopic = newTopic;
     activity.topicChangeTime = now;
-    logWithTime(`🔄 Смена темы в чате ${chatId}: ${activity.currentTopic} → ${newTopic}`);
+    logWithTime(
+      `🔄 Смена темы в чате ${chatId}: ${activity.currentTopic} → ${newTopic}`,
+    );
   }
-  
+
   chatActivity.set(chatId, activity);
 
   // Проверяем условия для автокомментирования:
   // 1. Прошло достаточно времени с последнего автокомментария
   // 2. Есть активность в чате (несколько сообщений за последние 5 минут)
   // 3. Случайный шанс сработал ИЛИ произошла смена темы
-  
+
   const timeSinceLastComment = (now - activity.lastAutoComment) / 1000;
-  const hasRecentActivity = activity.lastMessages.length >= 3; // Увеличиваем минимум до 3 сообщений
+  const hasRecentActivity =
+    activity.lastMessages.length >= MIN_MESSAGES_TO_TRIGGER; // Минимум сообщений для активности
   const cooldownPassed = timeSinceLastComment >= AUTO_COMMENT_COOLDOWN;
   const randomNum = Math.random() * 100;
   const randomChance = randomNum < AUTO_COMMENT_CHANCE;
@@ -256,10 +265,13 @@ function shouldAutoComment(chatId: number, messageText: string, userName: string
     topicChanged,
     topicChangeTrigger,
     currentTopic: activity.currentTopic,
-    willComment: (hasRecentActivity && cooldownPassed && randomChance) || topicChangeTrigger
+    willComment: (hasRecentActivity && cooldownPassed && randomChance) ||
+      topicChangeTrigger,
   });
 
-  if ((hasRecentActivity && cooldownPassed && randomChance) || topicChangeTrigger) {
+  if (
+    (hasRecentActivity && cooldownPassed && randomChance) || topicChangeTrigger
+  ) {
     activity.lastAutoComment = now;
     activity.messageCount = 0; // Сбрасываем счетчик
     chatActivity.set(chatId, activity);
@@ -305,16 +317,27 @@ function handleCommand(
   if (trimmedText === "/help") {
     const state = chatContext.get(msg.chat.id) ?? {};
     const currentStyle = state.style || DEFAULT_STYLE;
-    
-    const helpText = `🤖 This is a chatbot powered by OpenRouter models. You can use the following commands:
+
+    const helpText =
+      `🤖 This is a chatbot powered by OpenRouter models. You can use the following commands:
 
 /reload - Reset the conversation
 /style <text> - Set response style
 /help - Show this message
 
-${COMMENT_ALL_MESSAGES ? "✅ Commenting all messages in groups" : "❌ Only responding to @mentions in groups"}
-${currentStyle ? `🎭 Current style: ${currentStyle.slice(0, 50)}${currentStyle.length > 50 ? '...' : ''}` : '🎭 No style set'}`;
-    
+${
+        COMMENT_ALL_MESSAGES
+          ? "✅ Commenting all messages in groups"
+          : "❌ Only responding to @mentions in groups"
+      }
+${
+        currentStyle
+          ? `🎭 Current style: ${currentStyle.slice(0, 50)}${
+            currentStyle.length > 50 ? "..." : ""
+          }`
+          : "🎭 No style set"
+      }`;
+
     bot.sendMessage(msg.chat.id, helpText);
     return true;
   }
@@ -327,31 +350,38 @@ async function handleMessage(msg: TelegramBot.Message) {
   if (!msg.text) {
     return;
   }
-  
+
   // Игнорируем сообщения от самого бота
   if (msg.from?.is_bot && msg.from?.username === botName) {
     return;
   }
-  
-  const userName = `${msg.from?.first_name || ""} ${msg.from?.last_name || ""}`.trim() || msg.from?.username || "Unknown";
-  logWithTime(`📥 Получено сообщение в чате ${chatId} от ${userName}: ${msg.text}`);
-  
+
+  const userName =
+    `${msg.from?.first_name || ""} ${msg.from?.last_name || ""}`.trim() ||
+    msg.from?.username || "Unknown";
+  logWithTime(
+    `📥 Получено сообщение в чате ${chatId} от ${userName}: ${msg.text}`,
+  );
+
   // Инициализируем контекст при первом сообщении в чате
   const activity = chatActivity.get(chatId);
-  if (!activity?.isInitialized && (msg.chat.type === "group" || msg.chat.type === "supergroup")) {
+  if (
+    !activity?.isInitialized &&
+    (msg.chat.type === "group" || msg.chat.type === "supergroup")
+  ) {
     await initializeChatContext(chatId);
   }
-  
+
   // Обрабатываем команды в любом типе чата
   if (handleCommand(msg, msg.text.trim())) {
     return;
   }
-  
+
   // Для групповых чатов: умная логика автокомментирования
   // Для личных чатов: используем весь текст
   let trimmedText: string;
   let shouldRespond = false;
-  
+
   if (msg.chat.type === "group" || msg.chat.type === "supergroup") {
     if (msg.text.startsWith(`@${botName}`)) {
       // Если упоминают бота - ВСЕГДА отвечаем
@@ -364,22 +394,31 @@ async function handleMessage(msg: TelegramBot.Message) {
       shouldRespond = true;
     } else {
       // Новый умный режим: анализируем и вклиниваемся
-      const shouldAutoReply = shouldAutoComment(chatId, msg.text, userName);
-             if (shouldAutoReply) {
-         // Создаем контекст из последних сообщений для умного ответа
-         const activity = chatActivity.get(chatId);
-         const recentMessages = activity?.lastMessages || [];
-         
-         // Формируем контекст с именами пользователей
-         const contextWithUsers = recentMessages
-           .map(msg => `${msg.userName}: ${msg.text}`)
-           .join(" | ");
-         
-         const topicInfo = activity?.currentTopic ? `Тема: ${activity.currentTopic}. ` : "";
-         trimmedText = `${topicInfo}Контекст беседы: ${contextWithUsers}. Прокомментируй по теме, вклинься естественно.`;
-         shouldRespond = true;
-         logWithTime(`🤖 Автокомментарий в чате ${chatId} на основе ${recentMessages.length} сообщений, тема: ${activity?.currentTopic}`);
-       } else {
+      const shouldAutoReply = await shouldAutoComment(
+        chatId,
+        msg.text,
+        userName,
+      );
+      if (shouldAutoReply) {
+        // Создаем контекст из последних сообщений для умного ответа
+        const activity = chatActivity.get(chatId);
+        const recentMessages = activity?.lastMessages || [];
+
+        // Формируем контекст с именами пользователей
+        const contextWithUsers = recentMessages
+          .map((msg) => `${msg.userName}: ${msg.text}`)
+          .join(" | ");
+
+        const topicInfo = activity?.currentTopic
+          ? `Тема: ${activity.currentTopic}. `
+          : "";
+        trimmedText =
+          `${topicInfo}Контекст беседы: ${contextWithUsers}. Прокомментируй по теме, вклинься естественно.`;
+        shouldRespond = true;
+        logWithTime(
+          `🤖 Автокомментарий в чате ${chatId} на основе ${recentMessages.length} сообщений, тема: ${activity?.currentTopic}`,
+        );
+      } else {
         // Просто отслеживаем, но не отвечаем
         return;
       }
@@ -389,7 +428,7 @@ async function handleMessage(msg: TelegramBot.Message) {
     trimmedText = msg.text.trim();
     shouldRespond = true;
   }
-  
+
   if (!shouldRespond) {
     return;
   }
@@ -431,37 +470,41 @@ async function handleMessage(msg: TelegramBot.Message) {
         4000,
         { leading: true, trailing: false },
       ),
-         });
-     // Update conversationID and parentMessageID for this chat
-     chatContext.set(chatId, {
-       conversationID: response.conversationId,
-       parentMessageID: response.id,
-     });
-     
-     // Проверяем, просит ли пользователь пояснить что-то
-     const isAskingForExplanation = trimmedText.toLowerCase().includes("поясни") || 
-                                   trimmedText.toLowerCase().includes("объясни") ||
-                                   trimmedText.toLowerCase().includes("расскажи подробнее") ||
-                                   trimmedText.toLowerCase().includes("что ты имеешь в виду");
-     
-     // Ограничиваем длину ответа для краткости (если не просят пояснить)
-     const maxLength = isAskingForExplanation ? 500 : 200;
-     const limitedResponse = limitResponseLength(response.text, maxLength);
-     editMessage(respMsg, escapeMarkdown(limitedResponse));
-     logWithTime(`📨 Response (limited to ${maxLength} chars):`, limitedResponse);
-    
+    });
+    // Update conversationID and parentMessageID for this chat
+    chatContext.set(chatId, {
+      conversationID: response.conversationId,
+      parentMessageID: response.id,
+    });
+
+    // Проверяем, просит ли пользователь пояснить что-то
+    const isAskingForExplanation =
+      trimmedText.toLowerCase().includes("поясни") ||
+      trimmedText.toLowerCase().includes("объясни") ||
+      trimmedText.toLowerCase().includes("расскажи подробнее") ||
+      trimmedText.toLowerCase().includes("что ты имеешь в виду");
+
+    // Ограничиваем длину ответа для краткости (если не просят пояснить)
+    const maxLength = isAskingForExplanation ? 500 : 200;
+    const limitedResponse = limitResponseLength(response.text, maxLength);
+    editMessage(respMsg, escapeMarkdown(limitedResponse));
+    logWithTime(
+      `📨 Response (limited to ${maxLength} chars):`,
+      limitedResponse,
+    );
+
     // Логируем диалог в файл
     const chatType = msg.chat.type === "private" ? "PRIVATE" : "GROUP";
     const isAutoComment = trimmedText.includes("Контекст беседы:");
-    
-         await logDialog(
-       chatId,
-       chatType,
-       userName,
-       msg.text,
-       limitedResponse,
-       isAutoComment
-     );
+
+    await logDialog(
+      chatId,
+      chatType,
+      userName,
+      msg.text,
+      limitedResponse,
+      isAutoComment,
+    );
   } catch (err) {
     logWithTime("⛔️ OpenRouter API error:", err.message);
     // If the error contains session token has expired, then get a new session token
@@ -481,11 +524,11 @@ function limitResponseLength(text: string, maxLength: number = 200): string {
   if (text.length <= maxLength) {
     return text;
   }
-  
+
   // Ищем последнее предложение, которое поместится в лимит
-  const sentences = text.split(/[.!?]+/).filter(s => s.trim().length > 0);
+  const sentences = text.split(/[.!?]+/).filter((s) => s.trim().length > 0);
   let result = "";
-  
+
   for (const sentence of sentences) {
     const testResult = result + sentence + ".";
     if (testResult.length <= maxLength) {
@@ -494,13 +537,13 @@ function limitResponseLength(text: string, maxLength: number = 200): string {
       break;
     }
   }
-  
+
   // Если не удалось найти подходящие предложения, обрезаем по словам
   if (!result) {
     const words = text.split(" ");
     result = words.slice(0, Math.floor(maxLength / 8)).join(" ") + "...";
   }
-  
+
   return result;
 }
 

--- a/env.example
+++ b/env.example
@@ -6,3 +6,5 @@ DEFAULT_STYLE=Ты милая и дружелюбная помощница. От
 AUTO_COMMENT_CHANCE=25
 MIN_MESSAGES_TO_TRIGGER=3
 AUTO_COMMENT_COOLDOWN=180
+N8N_TOPIC_URL=https://your-n8n-endpoint.example
+N8N_TIMEOUT_MS=5000


### PR DESCRIPTION
## Summary
- call n8n workflow to analyze chat topics
- store returned topic in chat activity and use it in auto comments
- document n8n settings in env and README

## Testing
- `deno fmt chatbot.ts`
- `deno lint chatbot.ts`
- `deno check chatbot.ts` *(fails: error: Failed loading https://registry.npmjs.org/lodash for package "lodash": invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_688f534596fc832fa2c4409e4e40963e