### PR TITLE
Add topic detection workflow

### DIFF
--- a/topic-workflow.json
+++ b/topic-workflow.json
@@ -1,0 +1,78 @@
+{
+  "name": "Topic Detection Workflow",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "topic",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "Webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [200, 300]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "append",
+        "data": "={{$json}}"
+      },
+      "id": "Save Messages",
+      "name": "Save Messages",
+      "type": "n8n-nodes-base.datastore",
+      "typeVersion": 1,
+      "position": [450, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "const N = 5;\nconst store = $items(0,0).map(item => item.json);\nreturn [{ json: { messages: store.slice(-N) } }];"
+      },
+      "id": "Last N Messages",
+      "name": "Last N Messages",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [700, 300]
+    },
+    {
+      "parameters": {
+        "model": "gpt-3.5-turbo",
+        "messages": "={{$json[\"messages\"].map(m => ({ role: 'user', content: `${m.userName}: ${m.text}` }))}}",
+        "instruction": "определи тему"
+      },
+      "id": "Determine Topic",
+      "name": "Determine Topic",
+      "type": "n8n-nodes-base.openai",
+      "typeVersion": 1,
+      "position": [950, 300]
+    },
+    {
+      "parameters": {
+        "operation": "upsert",
+        "data": "={{[{topic: $json.data, startTime: Date.now()}]}}",
+        "options": { "updateKey": "topic" }
+      },
+      "id": "Store Topic",
+      "name": "Store Topic",
+      "type": "n8n-nodes-base.datastore",
+      "typeVersion": 1,
+      "position": [1200, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Save Messages", "type": "main", "index": 0 }]]
+    },
+    "Save Messages": {
+      "main": [[{ "node": "Last N Messages", "type": "main", "index": 0 }]]
+    },
+    "Last N Messages": {
+      "main": [[{ "node": "Determine Topic", "type": "main", "index": 0 }]]
+    },
+    "Determine Topic": {
+      "main": [[{ "node": "Store Topic", "type": "main", "index": 0 }]]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add n8n workflow with function node to gather last messages
- Use LLM node to determine chat topic
- Store topic with start time in Data Store

## Testing
- `deno fmt topic-workflow.json`
- `deno lint topic-workflow.json` *(fails: No target files found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5d2a94b0832faf07acff52a49cd5