### PR TITLE
feat: summarize chat batches for context

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,6 +3,4 @@ OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY
 OPENROUTER_MODEL=cognitivecomputations/dolphin-mistral-24b-venice-edition:free
 COMMENT_ALL_MESSAGES=false
 DEFAULT_STYLE=Ты милая и дружелюбная помощница. Отвечай кратко, по делу, максимум 2-3 предложения. Если тебя просят пояснить - тогда можешь дать подробный ответ.
-AUTO_COMMENT_CHANCE=25
-MIN_MESSAGES_TO_TRIGGER=3
-AUTO_COMMENT_COOLDOWN=180
+BATCH_SUMMARY_INTERVAL=300


### PR DESCRIPTION
## Summary
- track chat activity and summarize idle batches to maintain context
- include recent summaries when bot is mentioned to provide topic-aware replies
- add configurable `BATCH_SUMMARY_INTERVAL`
- remove automatic commenting; bot now replies only to mentions or when `COMMENT_ALL_MESSAGES` is true

## Testing
- `deno fmt chatbot.ts env.example`
- `deno lint chatbot.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac018cf9a4832f98c08d2d11a79ded