### PR TITLE
refactor: remove auto comment feature

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,6 +3,4 @@ OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY
 OPENROUTER_MODEL=cognitivecomputations/dolphin-mistral-24b-venice-edition:free
 COMMENT_ALL_MESSAGES=false
 DEFAULT_STYLE=Ты милая и дружелюбная помощница. Отвечай кратко, по делу, максимум 2-3 предложения. Если тебя просят пояснить - тогда можешь дать подробный ответ.
-AUTO_COMMENT_CHANCE=25
-MIN_MESSAGES_TO_TRIGGER=3
-AUTO_COMMENT_COOLDOWN=180
+BATCH_SUMMARY_INTERVAL=300


### PR DESCRIPTION
## Summary
- remove auto-comment constants and logic, keep batch summarization
- track chat activity with last messages for context
- respond to group messages only when mentioned

## Testing
- `deno fmt chatbot.ts env.example`
- `deno lint chatbot.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac1d097564832fbdba9aa8728a6d41